### PR TITLE
fix(loggers): do not set minify option by default

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -77,11 +77,7 @@ export default defineNuxtModule<ModuleOptions>({
             nuxt.options.vite.build
           )
         } else {
-          // In the default case, make sure minification by esbuild is turned on and set the drop option
-          nuxt.options.vite.build = defu(
-            { minify: true },
-            nuxt.options.vite.build
-          )
+          // In case of esbuild, set the drop option
           nuxt.options.vite.esbuild = defu(
             { 
               drop: ['console', 'debugger'] as ('console' | 'debugger')[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves #576

This PR changes the behaviour of the `removeLoggers` functionality to avoid potentially breaking third-party code.

Currently, the Nuxt Security module turns on Vite's build minification option by default. In some cases, it was found that this behaviour could have side-effects on third-party code.

With this PR, we do not modify the build `minify` option by default anymore.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
